### PR TITLE
fix(cache): use index N-1 when reading the inclusion list

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -106,15 +106,17 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
             .spec
             .is_focil_enabled_for_epoch(block.slot().epoch(T::EthSpec::slots_per_epoch()))
         {
+            // Inclusion lists are those submitted for the prior slot.
+            let il_slot = block.slot().saturating_sub(1_u64);
             let inclusion_list_transactions = chain
                 .inclusion_list_cache
                 .read()
-                .get_inclusion_list_transactions(block.slot())
+                .get_inclusion_list_transactions(il_slot)
                 .unwrap_or(vec![].into());
 
             info!(
-                tx_count =  inclusion_list_transactions.len(),
-                slot = ?block.slot(),
+                tx_count = inclusion_list_transactions.len(),
+                slot = ?il_slot,
                 "Adding inclusion list transactions in the Payload Notifier"
             );
             inclusion_list_transactions

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -869,13 +869,14 @@ impl HttpJsonRpc {
         &self,
         new_payload_request_eip7805: NewPayloadRequestEip7805<'_, E>,
     ) -> Result<PayloadStatusV1, Error> {
-        // TODO(focil) clean this up?
-        let mut il_transactions = vec![];
-        for transaction in new_payload_request_eip7805.il_transactions {
-            if let Ok(hex_tx) = String::from_utf8(transaction.into()).map(|v| format!("0x{}", v)) {
-                il_transactions.push(hex_tx);
-            }
-        }
+        let il_transactions: Vec<String> = new_payload_request_eip7805
+            .il_transactions
+            .into_iter()
+            .map(|tx| {
+                let bytes: Vec<u8> = tx.into();
+                format!("0x{}", hex::encode(bytes))
+            })
+            .collect();
 
         let params = json!([
             JsonExecutionPayload::V5(new_payload_request_eip7805.execution_payload.clone().into()),


### PR DESCRIPTION
## Issue Addressed

Lighthouse was passing 0 IL's to engine_newPayloadV5.

## Proposed Changes

Changed cache index to the correct N-1 index and revised serialization of IL's, which was also causing IL's to be empty.
