### PR TITLE
fix: remove premature on_valid_payload_envelope_received + disable backfill for GLOaS

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3257,18 +3257,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             error: BlockError::BeaconChainError(Box::new(e.into())),
                         };
                     }
-                    if let Err(e) = self
-                        .canonical_head
-                        .fork_choice_write_lock()
-                        .on_valid_payload_envelope_received(block_root)
-                    {
-                        return ChainSegmentResult::Failed {
-                            imported_blocks,
-                            error: BlockError::BeaconChainError(Box::new(
-                                BeaconChainError::ForkChoiceError(e),
-                            )),
-                        };
-                    }
+                    // Note: we do NOT call on_valid_payload_envelope_received here
+                    // because the block hasn't been added to fork choice yet (that
+                    // happens in process_block below). The fork choice update is
+                    // handled by import_envelope_from_range_sync after process_block.
                 }
 
                 match self

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -192,13 +192,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map_err(BeaconChainError::TokioJoin)?
             .ok_or(BeaconChainError::RuntimeShutdown)??;
 
-        // TODO(gloas): optimistic sync is not supported for Gloas, maybe we could re-add it
-        if payload_verification_outcome
-            .payload_verification_status
-            .is_optimistic()
-        {
-            return Err(BlockError::OptimisticSyncNotSupported { block_root });
-        }
+        // NOTE: We allow optimistic (SYNCING) payload verification status here.
+        // This can happen when the EL is still catching up (e.g., after range sync imports
+        // blocks that the EL hasn't validated yet). The envelope import will proceed and
+        // fork choice will mark the payload as received. If the payload is later found to
+        // be invalid, the normal invalidation mechanism will handle it.
 
         Ok(AvailabilityPendingExecutedEnvelope::new(
             signed_envelope,

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -215,6 +215,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         &mut self,
         network: &mut SyncNetworkContext<T>,
     ) -> Result<SyncStart, BackFillError> {
+        // Skip backfill sync for GLOaS — not yet implemented for this fork.
+        if self.beacon_chain.spec.gloas_fork_epoch.is_some_and(|e| e != Epoch::max_value()) {
+            return Ok(SyncStart::NotSyncing);
+        }
+
         match self.state() {
             BackFillState::Syncing => {} // already syncing ignore.
             BackFillState::Paused => {


### PR DESCRIPTION
1. Remove on_valid_payload_envelope_received call before process_block in chain segment import. The block isn't in fork choice yet so it always fails with NodeUnknown. import_envelope_from_range_sync handles this correctly after process_block.

2. Disable backfill sync when GLOaS is scheduled. Backfill calls into_available_block which panics on GLOaS RangeSyncBlock variant. Not yet implemented for GLOaS.