### PR TITLE
fix: only require parent envelope when bid references parent's payload

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -983,10 +983,15 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             .gloas_enabled();
         let parent_is_anchor = parent_block.parent_root.is_none();
 
+        // Check if this block's bid references a payload envelope we haven't received.
+        // Only trigger a lookup if the bid's parent_block_hash matches the parent block's
+        // committed execution_payload_block_hash (meaning this block builds directly on
+        // the parent's payload). If they don't match, the block is building on an older
+        // execution state (e.g. grandparent's) and doesn't need the parent's envelope.
         if parent_is_gloas
             && !parent_is_anchor
+            && Some(bid.message.parent_block_hash) == parent_block.execution_payload_block_hash
             && !fork_choice_read_lock.is_payload_received(&block.message().parent_root())
-            && Some(bid.message.parent_block_hash) != parent_block.execution_payload_block_hash
         {
             return Err(BlockError::ParentEnvelopeUnknown {
                 parent_root: block.message().parent_root(),


### PR DESCRIPTION
## Problem

When an envelope is rejected (e.g. `WithdrawalsRootMismatch` from a buggy proposer), the parent block's `payload_received` stays false permanently. The previous check in `block_verification.rs` then triggered `ParentEnvelopeUnknown` for **all** subsequent child blocks — even when those blocks' bids don't reference the broken parent's payload.

This caused a permanent stall: child blocks would trigger infinite lookup retries for the broken envelope, the lookup would fetch the same broken envelope, it would get rejected again, and the node could never advance past that slot.

## Fix

Only require the parent's envelope if the block's bid `parent_block_hash` matches the parent's `execution_payload_block_hash` — meaning this block directly depends on the parent's payload. If the bid builds on a different execution state (e.g. grandparent's payload, skipping the broken one), the block should be allowed through without needing the broken envelope.

## Before (broken logic)
```rust
if parent_is_gloas
    && !parent_is_anchor
    && !is_payload_received(parent_root)
    && bid.parent_block_hash != parent.execution_payload_block_hash
```

## After (fixed)
```rust
if parent_is_gloas
    && !parent_is_anchor
    && bid.parent_block_hash == parent.execution_payload_block_hash
    && !is_payload_received(parent_root)
```