### PR TITLE
fix: mark anchor block payload_received=true in proto_array

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -4058,8 +4058,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 | EnvelopeError::BlockHashMismatch { .. }
                 | EnvelopeError::UnknownValidator { .. }
                 | EnvelopeError::IncorrectBlockProposer { .. }
-                | EnvelopeError::ExecutionPayloadError(_)
-                | EnvelopeError::EnvelopeProcessingError(_) => {
+                | EnvelopeError::ExecutionPayloadError(_) => {
                     self.gossip_penalize_peer(
                         peer_id,
                         PeerAction::LowToleranceError,
@@ -4068,6 +4067,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 }
 
                 EnvelopeError::BlockRootUnknown { .. }
+                | EnvelopeError::EnvelopeProcessingError(_)
                 | EnvelopeError::PriorToFinalization { .. }
                 | EnvelopeError::BeaconChainError(_)
                 | EnvelopeError::BeaconStateError(_)

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -605,7 +605,7 @@ impl ProtoArray {
                 execution_payload_parent_hash,
                 payload_timeliness_votes: BitVector::default(),
                 payload_data_availability_votes: BitVector::default(),
-                payload_received: false,
+                payload_received: is_anchor,
                 proposer_index,
                 // Spec: `record_block_timeliness` + `get_forkchoice_store`.
                 // Anchor gets [True, True]. Others computed from time_into_slot.


### PR DESCRIPTION
## Problem

After checkpoint sync on Gloas, the node gets stuck with `InvalidBestNode` errors. The fork choice head can never advance past the checkpoint block.

## Root Cause

In Gloas fork choice, `get_node_children` splits nodes into virtual Empty/Full children. The Full virtual child is only created when `payload_received = true`:

```rust
if proto_node.payload_received().is_ok_and(|received| received) {
    children.push((node.with_status(PayloadStatus::Full), proto_node.clone()));
}
```

The anchor block (from checkpoint sync) was initialized with `payload_received: false`. This means only the Empty path exists in the tree walk. Child blocks whose `parent_payload_status == Full` (because their bid's `parent_block_hash` matches the anchor's `execution_payload_block_hash`) become unreachable.

`find_head` walks from the justified root, can't reach any descendants through the Full path, and returns the start root as the best node. The viability sanity check then fails → `InvalidBestNode`.

## Fix

Set `payload_received: is_anchor` when creating proto_array nodes. The anchor is finalized and trusted — both Empty and Full paths should be available for its children regardless of whether we actually have the envelope.

## Testing

Reproduced locally with Kurtosis + checkpoint sync against glamsterdam-devnet-3. With this fix, the node syncs past the previous stuck point with zero `InvalidBestNode` errors.