### PR TITLE
fix: use config-based fork for payload attestation domain

### DIFF
--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -378,10 +378,14 @@ where
         .data
         .slot
         .epoch(E::slots_per_epoch());
+    // Use config-based fork lookup rather than state.fork() to avoid
+    // race conditions during fork transitions where the head state
+    // may not yet reflect the new fork.
+    let fork = spec.fork_at_epoch(epoch);
     let domain = spec.get_domain(
         epoch,
         Domain::PTCAttester,
-        &state.fork(),
+        &fork,
         state.genesis_validators_root(),
     );
 


### PR DESCRIPTION
During fork transitions, the head state may not yet reflect the new fork version. This caused payload attestation signature verification to use the wrong domain (e.g. gloas instead of heze), resulting in peers being incorrectly banned for 'invalid signatures'.

Uses `spec.fork_at_epoch()` (derived from config) instead of `state.fork()` to compute the signing domain for payload attestations. This matches the approach used by Lodestar and avoids the head-advancement race condition.

Found during FOCIL interop testing with Lodestar + Besu on a minimal devnet (gloas epoch 1, heze epoch 2).