### PR TITLE
fix(gloas): prevent false peer bans from ePBS block/envelope race

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -556,7 +556,9 @@ impl<E: EthSpec> PeerManager<E> {
                     // Don't ban on this because we want to retry with a block by root request.
                     if matches!(
                         protocol,
-                        Protocol::BlobsByRoot | Protocol::DataColumnsByRoot
+                        Protocol::BlobsByRoot
+                            | Protocol::DataColumnsByRoot
+                            | Protocol::DataColumnsByRange
                     ) {
                         return;
                     }

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -305,7 +305,14 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                     // must have its columns in custody. In that case, set `true = enforce max_requests`
                     // and downscore if data_columns_by_root does not return the expected custody
                     // columns. For the rest of peers, don't downscore if columns are missing.
-                    lookup_peers.contains(&peer_id),
+                    //
+                    // In Gloas (ePBS), blocks and payload envelopes are decoupled. A peer may
+                    // have the block but not yet have received/processed the envelope containing
+                    // the blob data for columns. Don't enforce max_responses in this case.
+                    lookup_peers.contains(&peer_id)
+                        && !cx.chain.spec.fork_name_at_epoch(
+                            cx.chain.epoch().unwrap_or_default(),
+                        ).gloas_enabled(),
                 )
                 .map_err(Error::SendFailed)?;
 


### PR DESCRIPTION
## Problem

In Gloas devnets, Lighthouse nodes rapidly ban all their peers within minutes of the fork activating, causing the network to collapse.

### Root Causes

**1. Custody column request penalty (block/envelope race)**

In ePBS, the block and payload envelope are separate objects. When a peer gossips a block, other nodes do a lookup and request custody columns. But the proposer may not have published the envelope yet (25ms later). The responding peer returns 0 columns → requester penalizes with `LowToleranceError` → rapid score decay → ban.

The assumption `lookup_peers.contains(&peer_id) → must have columns` is invalid in Gloas since having the block doesn't mean having the envelope/columns.

**Fix:** Disable `expect_max_responses` enforcement for Gloas epochs since the block/envelope decoupling means a peer can legitimately have the block without columns.

**2. DataColumnsByRange ResourceUnavailable → Fatal ban**

During custody backfill sync, peers respond with `ResourceUnavailable` ("columns pruned within boundary"). This hits the default `PeerAction::Fatal` path for outgoing requests, instantly banning the peer.

`BlobsByRoot` and `DataColumnsByRoot` already skip banning for `ResourceUnavailable`, but `DataColumnsByRange` was missing from the skip list.

**Fix:** Add `DataColumnsByRange` to the skip list.

## Testing

Tested on a 6-node Kurtosis devnet (2 Lighthouse, 2 Prysm, 2 Lodestar) with `gloas_fork_epoch: 1` and `preset: minimal`. Without this fix, Lighthouse bans all peers within epoch 3-5. With this fix, peers remain connected.