### PR TITLE
fix: disable custody backfill sync peer penalty for missing columns

### DIFF
--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::{
-    NetworkGlobals, PeerAction, PeerId,
+    NetworkGlobals, PeerId,
     service::api_types::{CustodyBackFillBatchRequestId, CustodyBackfillBatchId},
     types::CustodyBackFillState,
 };
@@ -607,12 +607,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                         debug!(
                             ?error,
                             ?faulty_peer,
-                            "Custody backfill sync penalizing peer"
-                        );
-                        network.report_peer(
-                            faulty_peer,
-                            PeerAction::MidToleranceError,
-                            "Peer failed to serve columns",
+                            "Custody backfill sync: peer failed to serve columns (not penalizing)"
                         );
                     }
                 }


### PR DESCRIPTION
## Problem

The custody backfill sync penalizes peers with `MidToleranceError` when they fail to serve columns ("Bad or missing columns for some slots"). In Gloas (ePBS), peers may legitimately not have columns available due to:

1. The block/envelope decoupling — columns derive from the envelope which arrives separately
2. Lodestar/Prysm may not have stored columns for early slots

This causes score decay and eventual bans in small devnets.

## Fix

Remove the peer penalty entirely from the custody backfill sync path. Keep the debug log for visibility.

## Testing

Tested on a 6-node Kurtosis devnet (2 Lighthouse, 2 Prysm, 2 Lodestar) with `gloas_fork_epoch: 1` and `preset: minimal`. Without this fix, Lodestar peers get penalized immediately at epoch 5. With this fix, the network runs for 80+ epochs with zero peer score degradation.