### PR TITLE
fix(gloas): queue gossip data columns for reprocessing when block root is unknown

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -41,8 +41,8 @@
 pub use crate::scheduler::BeaconProcessorQueueLengths;
 use crate::scheduler::work_queue::WorkQueues;
 use crate::work_reprocessing_queue::{
-    QueuedBackfillBatch, QueuedColumnReconstruction, QueuedGossipBlock, QueuedGossipEnvelope,
-    ReprocessQueueMessage,
+    QueuedBackfillBatch, QueuedColumnReconstruction, QueuedGossipBlock, QueuedGossipDataColumn,
+    QueuedGossipEnvelope, ReprocessQueueMessage,
 };
 use futures::stream::{Stream, StreamExt};
 use futures::task::Poll;
@@ -304,6 +304,10 @@ impl<E: EthSpec> From<ReadyWork> for WorkEvent<E> {
                     work: Work::ColumnReconstruction(process_fn),
                 }
             }
+            ReadyWork::DataColumn(QueuedGossipDataColumn { process_fn, .. }) => Self {
+                drop_during_sync: true,
+                work: Work::UnknownBlockAttestation { process_fn },
+            },
         }
     }
 }

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -123,6 +123,8 @@ pub enum ReprocessQueueMessage {
     UnknownLightClientOptimisticUpdate(QueuedLightClientUpdate),
     /// A new backfill batch that needs to be scheduled for processing.
     BackfillSync(QueuedBackfillBatch),
+    /// A gossip data column that references an unknown block.
+    UnknownBlockDataColumn(QueuedGossipDataColumn),
     /// A delayed column reconstruction that needs checking
     DelayColumnReconstruction(QueuedColumnReconstruction),
 }
@@ -138,6 +140,7 @@ pub enum ReadyWork {
     LightClientUpdate(QueuedLightClientUpdate),
     BackfillSync(QueuedBackfillBatch),
     ColumnReconstruction(QueuedColumnReconstruction),
+    DataColumn(QueuedGossipDataColumn),
 }
 
 /// An Attestation for which the corresponding block was not seen while processing, queued for
@@ -198,6 +201,12 @@ pub struct QueuedColumnReconstruction {
     pub block_root: Hash256,
     pub slot: Slot,
     pub process_fn: AsyncFn,
+}
+
+/// A gossip data column that references an unknown block, queued for later reprocessing.
+pub struct QueuedGossipDataColumn {
+    pub beacon_block_root: Hash256,
+    pub process_fn: BlockingFn,
 }
 
 impl<E: EthSpec> TryFrom<WorkEvent<E>> for QueuedBackfillBatch {
@@ -284,10 +293,15 @@ struct ReprocessQueue<S> {
     queued_column_reconstructions: HashMap<Hash256, Option<DelayKey>>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
+    /// Queued gossip data columns awaiting their block.
+    queued_gossip_data_columns: FnvHashMap<usize, (QueuedGossipDataColumn, DelayKey)>,
+    /// Data columns per block root.
+    awaiting_data_columns_per_root: HashMap<Hash256, Vec<usize>>,
 
     /* Aux */
     /// Next attestation id, used for both aggregated and unaggregated attestations
     next_attestation: usize,
+    next_data_column: usize,
     next_lc_update: usize,
     early_block_debounce: TimeLatch,
     envelope_delay_debounce: TimeLatch,
@@ -464,7 +478,10 @@ impl<S: SlotClock> ReprocessQueue<S> {
             awaiting_lc_updates_per_parent_root: HashMap::new(),
             queued_backfill_batches: Vec::new(),
             queued_column_reconstructions: HashMap::new(),
+            queued_gossip_data_columns: FnvHashMap::default(),
+            awaiting_data_columns_per_root: HashMap::new(),
             next_attestation: 0,
+            next_data_column: 0,
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
             envelope_delay_debounce: TimeLatch::default(),
@@ -688,6 +705,30 @@ impl<S: SlotClock> ReprocessQueue<S> {
 
                 self.next_attestation += 1;
             }
+            InboundEvent::Msg(UnknownBlockDataColumn(queued_data_column)) => {
+                if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_ATTESTATIONS {
+                    return;
+                }
+
+                let col_id = self.next_data_column;
+
+                // Register the delay (reuse attestation delay queue with offset IDs).
+                let delay_key = self
+                    .attestations_delay_queue
+                    .insert(QueuedAttestationId::Unaggregate(col_id.wrapping_add(10_000_000)), QUEUED_ATTESTATION_DELAY);
+
+                // Register this column for the corresponding block root.
+                self.awaiting_data_columns_per_root
+                    .entry(queued_data_column.beacon_block_root)
+                    .or_default()
+                    .push(col_id);
+
+                // Store the column and its info.
+                self.queued_gossip_data_columns
+                    .insert(col_id, (queued_data_column, delay_key));
+
+                self.next_data_column += 1;
+            }
             InboundEvent::Msg(UnknownLightClientOptimisticUpdate(
                 queued_light_client_optimistic_update,
             )) => {
@@ -798,6 +839,29 @@ impl<S: SlotClock> ReprocessQueue<S> {
                             sent_count,
                             "Ignored scheduled attestation(s) for block"
                         );
+                    }
+                }
+
+                // Unqueue the data columns we have for this root, if any.
+                if let Some(queued_ids) =
+                    self.awaiting_data_columns_per_root.remove(&block_root)
+                {
+                    for col_id in queued_ids {
+                        if let Some((data_column, delay_key)) =
+                            self.queued_gossip_data_columns.remove(&col_id)
+                        {
+                            self.attestations_delay_queue.remove(&delay_key);
+                            if self
+                                .ready_work_tx
+                                .try_send(ReadyWork::DataColumn(data_column))
+                                .is_err()
+                            {
+                                error!(
+                                    ?block_root,
+                                    "Failed to send data column for reprocessing"
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -64,8 +64,8 @@ use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;
 use beacon_processor::{
     DuplicateCache, GossipAggregatePackage, GossipAttestationBatch,
     work_reprocessing_queue::{
-        QueuedAggregate, QueuedGossipBlock, QueuedGossipEnvelope, QueuedLightClientUpdate,
-        QueuedUnaggregate, ReprocessQueueMessage,
+        QueuedAggregate, QueuedGossipBlock, QueuedGossipDataColumn, QueuedGossipEnvelope,
+        QueuedLightClientUpdate, QueuedUnaggregate, ReprocessQueueMessage,
     },
 };
 
@@ -728,19 +728,46 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         ..
                     } => {
                         debug!(
-                            action = "ignoring",
+                            action = "queuing for reprocessing",
                             %unknown_block_root,
                             "Unknown block root for column"
                         );
-                        // TODO(gloas): wire this into proper lookup sync. Sending
-                        // `UnknownBlockHashFromAttestation` here is a Fulu-shaped fallback that
-                        // mixes column processing with the attestation lookup path and is not
-                        // the right primitive for Gloas column lookups.
                         self.propagate_validation_result(
-                            message_id,
+                            message_id.clone(),
                             peer_id,
                             MessageAcceptance::Ignore,
                         );
+
+                        // Queue the column for reprocessing when the block arrives.
+                        let processor = self.clone();
+                        let reprocess_msg = ReprocessQueueMessage::UnknownBlockDataColumn(
+                            QueuedGossipDataColumn {
+                                beacon_block_root: unknown_block_root,
+                                process_fn: Box::new(move || {
+                                    // Re-dispatch through the normal gossip column processing path.
+                                    let _ = processor.send_gossip_data_column_sidecar(
+                                        message_id,
+                                        peer_id,
+                                        subnet_id,
+                                        column_sidecar,
+                                        seen_duration,
+                                    );
+                                }),
+                            },
+                        );
+                        if self
+                            .beacon_processor_send
+                            .try_send(WorkEvent {
+                                drop_during_sync: false,
+                                work: Work::Reprocess(reprocess_msg),
+                            })
+                            .is_err()
+                        {
+                            debug!(
+                                %unknown_block_root,
+                                "Failed to queue data column for reprocessing"
+                            );
+                        }
                     }
                     GossipDataColumnError::InvalidVariant
                     | GossipDataColumnError::PubkeyCacheTimeout


### PR DESCRIPTION
## Problem

In ePBS (Gloas), data columns frequently arrive via gossip **before** their corresponding block (~50ms earlier). When this happens, the `GossipDataColumnError::BlockRootUnknown` handler silently ignores the columns. Once ignored, those columns are lost and never re-processed.

This causes blocks to get stuck at `data_columns 0/128` — the block is imported but never becomes fully data-available. Fork choice can't advance the head, causing:
1. Head gets stuck at the previous slot
2. Shuffling diverges from the rest of the network (different decision block)
3. Attestations from other clients get skipped as "incompatible shuffling"
4. PTC disagreements cascade into peer bans
5. Network collapses around epoch 80

## Fix

Add a reprocess queue path for gossip data columns with unknown block roots:
- New `QueuedGossipDataColumn` struct and `UnknownBlockDataColumn` message variant
- When `BlockRootUnknown` is hit, queue the column with its block root
- On `BlockImported`, release all queued columns for that root and re-dispatch them through the normal gossip column processing path (`send_gossip_data_column_sidecar`)

This mirrors the existing pattern for attestations (`UnknownBlockUnaggregate`) and envelopes (`UnknownBlockForEnvelope`).

## Testing

Tested on a 6-node Kurtosis devnet. Without this fix, network collapses at epoch ~80 when columns arrive before blocks. With this fix, network stays healthy past epoch 80+.