### PR TITLE
Tighten allowed slots for proposer index computation

### DIFF
--- a/consensus/types/src/state/beacon_state.rs
+++ b/consensus/types/src/state/beacon_state.rs
@@ -1127,21 +1127,33 @@ impl<E: EthSpec> BeaconState<E> {
             // Post-Fulu we must never compute proposer indices using insufficient lookahead. This
             // would be very dangerous as it would lead to conflicts between the *true* proposer as
             // defined by `self.proposer_lookahead` and the output of this function.
-            // With MIN_SEED_LOOKAHEAD=1 (common config), this is equivalent to checking that the
-            // requested epoch is not the current epoch.
             //
-            // We do not run this check if this function is called from `upgrade_to_fulu`,
-            // which runs *after* the slot is incremented, and needs to compute the proposer
-            // shuffling for the epoch that was just transitioned into.
-            if self.fork_name_unchecked().fulu_enabled()
-                && epoch < current_epoch.safe_add(spec.min_seed_lookahead)?
-            {
-                return Err(
-                    BeaconStateError::ComputeProposerIndicesInsufficientLookahead {
-                        current_epoch,
-                        request_epoch: epoch,
-                    },
-                );
+            // Furthermore, post-Gloas, we must never compute proposers at any slot other than the
+            // dependent root slot itself, as slashings at subsequent slots have the ability to
+            // change the shuffling.
+            //
+            // For simplicity these two checks are combined into a single check on the dependent
+            // slot, which is safe for Fulu and Gloas. This function is always called from
+            // `get_beacon_proposer_indices`, which uses the cached lookahead for `current_epoch` and
+            // `next_epoch`. The only epoch's shuffling that should ordinarily be computed therefore
+            // is `next_epoch + 1`, which for Fulu and Gloas is computed during the epoch transition
+            // in the last slot of `current_epoch` (before the slot is incremented into
+            // `next_epoch`).
+            //
+            // The only case where computation of proposers in `current_epoch` and `next_epoch` is
+            // directly required is during the fork to Fulu itself
+            // (`upgrade_to_fulu`/`initialize_proposer_lookahead`), in which case the state is not
+            // yet the Fulu variant, and we omit the check.
+            if self.fork_name_unchecked().fulu_enabled() {
+                let dependent_slot = spec.proposer_shuffling_decision_slot::<E>(epoch);
+                if self.slot() != dependent_slot {
+                    return Err(
+                        BeaconStateError::ComputeProposerIndicesInsufficientLookahead {
+                            current_epoch,
+                            request_epoch: epoch,
+                        },
+                    );
+                }
             }
         } else {
             // Pre-Fulu the situation is reversed, we *should not* compute proposer indices using
@@ -1375,7 +1387,7 @@ impl<E: EthSpec> BeaconState<E> {
         spec: &ChainSpec,
     ) -> Result<Vec<usize>, BeaconStateError> {
         // This isn't in the spec, but we remove the footgun that is requesting the current epoch
-        // for a Fulu state.
+        // or next epoch for a Fulu state.
         if let Ok(proposer_lookahead) = self.proposer_lookahead()
             && epoch >= self.current_epoch()
             && epoch <= self.next_epoch()?


### PR DESCRIPTION
Spent way too long thinking about EIP-8045 and all I came up with was this sanity check.

The key idea is that we shouldn't allow _computation_ of proposer indices at any slot after the decision root slot.

Prior to Gloas the decision root meant something like:

> You can compute the proposer shuffling using any state that agrees with this decision root and has not diverged in `effective_balances` (in practice: the state at the decision slot, or any state descended from it prior to the subsequent epoch boundary).

Now post-Gloas (with EIP-8045) it means:

> You can ONLY compute the proposer shuffling using the state at the decision slot itself. After that the proposer shuffling is liable to change due to slashings.

The sanity check guards against us accidentally using a state that has more information than it should (new slashings), but DOES NOT protect against a state from the decision slot with _too little_ information (we can't tell whether the latest block from `decision_slot` is/should have been applied, and we can't tell whether the epoch transition affecting effective balances has already happened as it should have).